### PR TITLE
chore: check conventional commits format

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -12,9 +12,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Conventional commits check
+        uses: oknozor/cocogitto-action@v2
+        with:
+          check-latest-tag-only: true
       - name: Inject slug/short variables
         uses: rlespinasse/github-slug-action@v4
-
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v3
         with:


### PR DESCRIPTION
Introduces a ci check for commits to respect the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format